### PR TITLE
Use LazyThreadSafetyMode.NONE

### DIFF
--- a/core/src/main/java/dev/marcellogalhardo/retained/core/RetainedObject.kt
+++ b/core/src/main/java/dev/marcellogalhardo/retained/core/RetainedObject.kt
@@ -66,7 +66,7 @@ fun <T : Any> createRetainedObjectLazy(
     getSavedStateRegistryOwner: () -> SavedStateRegistryOwner,
     getDefaultArgs: () -> Bundle = { bundleOf() },
     createRetainedObject: (RetainedEntry) -> T
-): Lazy<T> = lazy {
+): Lazy<T> = lazy(LazyThreadSafetyMode.NONE) {
     createRetainedObject(key, getViewModelStoreOwner(), getSavedStateRegistryOwner(), getDefaultArgs(), createRetainedObject)
 }
 


### PR DESCRIPTION
Just changing the `lazy` call to move away from the default `LazyThreadSafetyMode.SYNCHRONIZED` since we don't really need the cost of the double-checked locking used to ensure only one object is created for the cases where the extensions here will be used.