### PR TITLE
Externalize and bump a few versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,9 @@
 
 buildscript {
     ext.kotlin_version = '1.4.21'
+    ext.lifecycle_version = '2.3.0'
+    ext.activity_version = '1.2.0'
+    ext.fragment_version = '1.3.0'
     ext.compose_version = '1.0.0-alpha09'
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.4.21'
+    ext.kotlin_version = '1.4.30'
     ext.lifecycle_version = '2.3.0'
     ext.activity_version = '1.2.0'
     ext.fragment_version = '1.3.0'

--- a/compose/build.gradle
+++ b/compose/build.gradle
@@ -51,9 +51,8 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
-    implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-savedstate:2.2.0'
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:$lifecycle_version"
 
     implementation "androidx.navigation:navigation-compose:1.0.0-alpha06"
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -39,11 +39,10 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
-    implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-savedstate:2.2.0'
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:$lifecycle_version"
 
-    implementation 'androidx.activity:activity-ktx:1.1.0'
+    implementation "androidx.activity:activity-ktx:$activity_version"
 
     // Unit Testing
     testImplementation 'junit:junit:4.13.1'

--- a/fragment/build.gradle
+++ b/fragment/build.gradle
@@ -41,12 +41,11 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
-    implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-savedstate:2.2.0'
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:$lifecycle_version"
 
-    implementation 'androidx.activity:activity-ktx:1.1.0'
-    implementation 'androidx.fragment:fragment-ktx:1.2.5'
+    implementation "androidx.activity:activity-ktx:$activity_version"
+    implementation "androidx.fragment:fragment-ktx:$fragment_version"
 
     // Unit Testing
     testImplementation 'junit:junit:4.13.1'

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -37,11 +37,10 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.core:core-ktx:1.3.2'
-    implementation 'androidx.fragment:fragment-ktx:1.2.5'
+    implementation "androidx.fragment:fragment-ktx:$fragment_version"
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
-    implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-savedstate:2.2.0'
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:$lifecycle_version"
 
     implementation project(':core')
     implementation project(':fragment')


### PR DESCRIPTION
There's some important stable releases, so I'm bumping them here:

- `activity` from 1.1.0 to [1.2.0](https://developer.android.com/jetpack/androidx/releases/activity#1.2.0)
- `fragment` from 1.2.5 to [1.3.0](https://developer.android.com/jetpack/androidx/releases/fragment#1.3.0)
- `lifecycler` from 2.2.0 to [2.3.0](https://developer.android.com/jetpack/androidx/releases/lifecycle#lifecycle-*-2.3.0)

I'm also removing removing the [deprecated lifecycle-extensions artefact](https://developer.android.com/jetpack/androidx/releases/lifecycle#declaring_dependencies).

----

I have a couple of open questions: 

- Should we also bump Kotlin and/or Compose? Kotlin looks harmless but I'm completely out of the loop when it comes to Compose.
- Should we get rid of the test dependencies since they're not being used? Otherwise I should probably externalize them as well to avoid the repetition, but I think it would be easier to just remove them.