### PR TITLE
Fix exception in docs: IllegalArgument -> IllegalStateException

### DIFF
--- a/compose/src/main/java/dev/marcellogalhardo/retained/compose/ComposeRetainedObject.kt
+++ b/compose/src/main/java/dev/marcellogalhardo/retained/compose/ComposeRetainedObject.kt
@@ -30,7 +30,7 @@ import dev.marcellogalhardo.retained.core.createRetainedObject
  * ```
  *
  * This property can be accessed only after the [LifecycleOwner] is ready to use Jetpack
- * [ViewModel], and access prior to that will result in [IllegalArgumentException].
+ * [ViewModel], and access prior to that will result in [IllegalStateException].
  *
  * @see createRetainedObject
  */

--- a/core/src/main/java/dev/marcellogalhardo/retained/core/ActivityRetainedObject.kt
+++ b/core/src/main/java/dev/marcellogalhardo/retained/core/ActivityRetainedObject.kt
@@ -17,7 +17,7 @@ import androidx.core.os.bundleOf
  * ```
  *
  * This property can be accessed only after the [ComponentActivity] is attached to the [Application],
- * and access prior to that will result in [IllegalArgumentException].
+ * and access prior to that will result in [IllegalStateException].
  *
  * @see createRetainedObject
  */

--- a/core/src/main/java/dev/marcellogalhardo/retained/core/RetainedObject.kt
+++ b/core/src/main/java/dev/marcellogalhardo/retained/core/RetainedObject.kt
@@ -32,7 +32,7 @@ import kotlinx.coroutines.DisposableHandle
  * ```
  *
  * This property can be accessed only after the [LifecycleOwner] is ready to use Jetpack
- * [ViewModel], and access prior to that will result in [IllegalArgumentException].
+ * [ViewModel], and access prior to that will result in [IllegalStateException].
  *
  * @param key A String that will be used to identify the retained instance in this scope.
  * @param viewModelStoreOwner The [ViewModelStoreOwner] used to scope the retained instance.

--- a/fragment/src/main/java/dev/marcellogalhardo/retained/fragment/FragmentRetainedObject.kt
+++ b/fragment/src/main/java/dev/marcellogalhardo/retained/fragment/FragmentRetainedObject.kt
@@ -29,7 +29,7 @@ import dev.marcellogalhardo.retained.core.createRetainedObjectLazy
  * ```
  *
  * This property can be accessed only after this [Fragment] is attached i.e., after
- * [Fragment.onAttach], and access prior to that will result in [IllegalArgumentException].
+ * [Fragment.onAttach], and access prior to that will result in [IllegalStateException].
  *
  * @see createRetainedObject
  */
@@ -53,7 +53,7 @@ inline fun <reified T : Any> Fragment.retain(
  * ```
  *
  * This property can be accessed only after this [Fragment] is attached i.e., after
- * [Fragment.onAttach], and access prior to that will result in [IllegalArgumentException].
+ * [Fragment.onAttach], and access prior to that will result in [IllegalStateException].
  *
  * @see createRetainedObject
  */
@@ -77,7 +77,7 @@ inline fun <reified T : Any> Fragment.retainInActivity(
  * ```
  *
  * This property can be accessed only after this [Fragment] is attached i.e., after
- * [Fragment.onAttach], and access prior to that will result in [IllegalArgumentException].
+ * [Fragment.onAttach], and access prior to that will result in [IllegalStateException].
  *
  * @see createRetainedObject
  */


### PR DESCRIPTION
I thought about including this in the [view PR](https://github.com/marcellogalhardo/retained/pull/6), but decided it would be better to keep the clean scope we currently have there. You can verify what exception is thrown for activities [here](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:activity/activity/src/main/java/androidx/activity/ComponentActivity.java;l=467-474?q=ComponentActivity.java) and for fragments [here](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:fragment/fragment/src/main/java/androidx/fragment/app/Fragment.java;l=396-406?q=Fragment.java&ss=androidx%2Fplatform%2Fframeworks%2Fsupport:fragment%2F).