### PR TITLE
Replace 'JCenter' by 'MavenCentral'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.compose_version = '1.0.0-alpha12'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.0-beta04'
@@ -25,7 +25,7 @@ plugins {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven { url "https://jitpack.io" }
     }
 }


### PR DESCRIPTION
JCenter is at end of life. For more details, check: https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/