### PR TITLE
Use same approach in all methods to load default args

### DIFF
--- a/core/src/main/java/dev/marcellogalhardo/retained/core/ActivityRetainedObject.kt
+++ b/core/src/main/java/dev/marcellogalhardo/retained/core/ActivityRetainedObject.kt
@@ -1,7 +1,6 @@
 package dev.marcellogalhardo.retained.core
 
 import android.app.Application
-import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.core.os.bundleOf
 
@@ -24,6 +23,6 @@ import androidx.core.os.bundleOf
 @OptIn(InternalRetainedApi::class)
 inline fun <reified T : Any> ComponentActivity.retain(
     key: String = T::class.java.name,
-    noinline getDefaultArgs: () -> Bundle = { intent?.extras ?: bundleOf() },
+    noinline getDefaultArgs: GetDefaultArgs? = null,
     noinline createRetainedObject: (RetainedEntry) -> T
-): Lazy<T> = createRetainedObjectLazy(key, T::class, { this }, { this }, getDefaultArgs, createRetainedObject)
+): Lazy<T> = createRetainedObjectLazy(key, T::class, { this }, { this }, getDefaultArgs ?: { intent?.extras ?: bundleOf() }, createRetainedObject)

--- a/core/src/main/java/dev/marcellogalhardo/retained/core/GetDefaultArgs.kt
+++ b/core/src/main/java/dev/marcellogalhardo/retained/core/GetDefaultArgs.kt
@@ -1,0 +1,5 @@
+package dev.marcellogalhardo.retained.core
+
+import android.os.Bundle
+
+typealias GetDefaultArgs = () -> Bundle

--- a/core/src/main/java/dev/marcellogalhardo/retained/core/RetainedObject.kt
+++ b/core/src/main/java/dev/marcellogalhardo/retained/core/RetainedObject.kt
@@ -47,7 +47,7 @@ fun <T : Any> createRetainedObject(
     classRef: KClass<out T>,
     viewModelStoreOwner: ViewModelStoreOwner,
     savedStateRegistryOwner: SavedStateRegistryOwner,
-    defaultArgs: Bundle = bundleOf(),
+    defaultArgs: Bundle,
     createRetainedObject: (RetainedEntry) -> T
 ): T {
     val factory = RetainedViewModelFactory(
@@ -73,10 +73,10 @@ fun <T : Any> createRetainedObjectLazy(
     classRef: KClass<out T>,
     getViewModelStoreOwner: () -> ViewModelStoreOwner,
     getSavedStateRegistryOwner: () -> SavedStateRegistryOwner,
-    getDefaultArgs: () -> Bundle = { bundleOf() },
+    getDefaultArgs: GetDefaultArgs? = null,
     createRetainedObject: (RetainedEntry) -> T
 ): Lazy<T> = lazy(LazyThreadSafetyMode.NONE) {
-    createRetainedObject(key, classRef, getViewModelStoreOwner(), getSavedStateRegistryOwner(), getDefaultArgs(), createRetainedObject)
+    createRetainedObject(key, classRef, getViewModelStoreOwner(), getSavedStateRegistryOwner(), getDefaultArgs?.invoke() ?: bundleOf(), createRetainedObject)
 }
 
 private class RetainedViewModel(

--- a/fragment/src/main/java/dev/marcellogalhardo/retained/fragment/FragmentRetainedObject.kt
+++ b/fragment/src/main/java/dev/marcellogalhardo/retained/fragment/FragmentRetainedObject.kt
@@ -7,6 +7,7 @@ import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.savedstate.SavedStateRegistryOwner
+import dev.marcellogalhardo.retained.core.GetDefaultArgs
 import dev.marcellogalhardo.retained.core.InternalRetainedApi
 import dev.marcellogalhardo.retained.core.RetainedEntry
 import dev.marcellogalhardo.retained.core.createRetainedObjectLazy
@@ -36,10 +37,10 @@ import dev.marcellogalhardo.retained.core.createRetainedObjectLazy
 @OptIn(InternalRetainedApi::class)
 inline fun <reified T : Any> Fragment.retain(
     key: String = T::class.java.name,
-    noinline getDefaultArgs: () -> Bundle = { arguments ?: bundleOf() },
+    noinline getDefaultArgs: GetDefaultArgs? = null,
     noinline getFragment: () -> Fragment = { this },
     noinline createRetainedObject: (RetainedEntry) -> T
-): Lazy<T> = createRetainedObjectLazy(key, T::class, getFragment, getFragment, getDefaultArgs, createRetainedObject)
+): Lazy<T> = createRetainedObjectLazy(key, T::class, getFragment, getFragment, getDefaultArgs ?: { arguments ?: bundleOf() }, createRetainedObject)
 
 /**
  * Returns a [Lazy] delegate to access a retained object by **default** scoped to this

--- a/navigation-fragment/src/main/java/dev/marcellogalhardo/retained/navigation/fragment/NavigationFragmentRetainedObject.kt
+++ b/navigation-fragment/src/main/java/dev/marcellogalhardo/retained/navigation/fragment/NavigationFragmentRetainedObject.kt
@@ -1,10 +1,10 @@
 package dev.marcellogalhardo.retained.navigation.fragment
 
-import android.os.Bundle
 import androidx.annotation.IdRes
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
+import dev.marcellogalhardo.retained.core.GetDefaultArgs
 import dev.marcellogalhardo.retained.core.InternalRetainedApi
 import dev.marcellogalhardo.retained.core.RetainedEntry
 import dev.marcellogalhardo.retained.core.createRetainedObjectLazy
@@ -29,7 +29,7 @@ import dev.marcellogalhardo.retained.core.createRetainedObjectLazy
 inline fun <reified T : Any> Fragment.retainInNavGraph(
     @IdRes navGraphId: Int,
     key: String = T::class.java.name,
-    noinline getDefaultArgs: (() -> Bundle)? = null,
+    noinline getDefaultArgs: GetDefaultArgs? = null,
     noinline createRetainedObject: (RetainedEntry) -> T
 ): Lazy<T> {
     val backStackEntry by lazy(LazyThreadSafetyMode.NONE) { findNavController().getBackStackEntry(navGraphId) }


### PR DESCRIPTION
Ensure that all `retain` methods use same approach to load arguments.