### PR TITLE
Change license name and URL

### DIFF
--- a/scripts/publish-module.gradle
+++ b/scripts/publish-module.gradle
@@ -46,8 +46,8 @@ afterEvaluate {
                     url = 'https://github.com/getstream/stream-chat-android'
                     licenses {
                         license {
-                            name = 'Retained'
-                            url = 'https://github.com/marcellogalhardo/retained/blob/main/LICENSE'
+                            name = 'Apache License 2.0'
+                            url = 'http://www.apache.org/licenses/LICENSE-2.0'
                         }
                     }
                     developers {


### PR DESCRIPTION
The goal here is to make the library more friendly towards things like [Licensee](https://github.com/cashapp/licensee). I'm taking the name and URL from [SPDX](https://spdx.org/licenses/Apache-2.0.html).

Right now this is Licensee's output for Retained:

> \- ERROR: Unknown license URL 'https://github.com/marcellogalhardo/retained/blob/main/LICENSE' is NOT allowed