### PR TITLE
Bump build tools

### DIFF
--- a/navigation-view/build.gradle
+++ b/navigation-view/build.gradle
@@ -8,12 +8,12 @@ ext {
 apply from: "${rootProject.projectDir}/scripts/publish-module.gradle"
 
 android {
-    compileSdkVersion 31
-    buildToolsVersion "30.0.2"
+    compileSdkVersion 32
+    buildToolsVersion "30.0.3"
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 32
         versionCode 1
         versionName "1.0"
 

--- a/scripts/publish-module.gradle
+++ b/scripts/publish-module.gradle
@@ -3,7 +3,7 @@ apply plugin: 'signing'
 
 ext {
     PUBLISH_GROUP_ID = 'dev.marcellogalhardo'
-    PUBLISH_VERSION = '0.14.1'
+    PUBLISH_VERSION = '0.15.0'
 }
 
 task androidSourcesJar(type: Jar) {


### PR DESCRIPTION
Bump build tools to 32. That was missed by Pull Request #63. Also, includes a version bump to 0.15.0 for all `retained` artifacts.