### PR TITLE
Remove unnecessary arg from retainInActivity

### DIFF
--- a/compose/src/main/java/dev/marcellogalhardo/retained/compose/ComposeRetained.kt
+++ b/compose/src/main/java/dev/marcellogalhardo/retained/compose/ComposeRetained.kt
@@ -59,19 +59,16 @@ public inline fun <reified T : Any> retain(
 @ExperimentalRetainedApi
 @Composable
 public inline fun <reified T : Any> retainInActivity(
-    owner: ViewModelStoreOwner?,
     key: String = T::class.java.name,
     noinline instantiate: @DisallowComposableCalls (RetainedEntry) -> T,
-): T = retain(
-    key = key,
-    owner = if (owner != null) {
-        owner
-    } else {
-        val context = LocalContext.current
-        remember { context.findActivity() }
-    },
-    instantiate = instantiate,
-)
+): T {
+    val context = LocalContext.current
+    return retain(
+        key = key,
+        owner = remember { context.findActivity() },
+        instantiate = instantiate,
+    )
+}
 
 @PublishedApi
 internal tailrec fun Context.findActivity(): ComponentActivity = when (this) {


### PR DESCRIPTION
If we pass an `owner` to `retainInActivity()`, it basically acts as `retain()`, so we probably don’t want that there. Based on the example in the docs, we also want to be able to call `retainInActivity()` without passing any arg other than the `instantiate`, which we can’t do while `owner` is around. So this PR is basically removing the `owner` arg from the `retainInActivity` function.